### PR TITLE
Add SSL Verify option to HTML + python code

### DIFF
--- a/bin/http_alert.py
+++ b/bin/http_alert.py
@@ -27,6 +27,12 @@ def helper_get_requests_func(method):
     elif method == "put":
         return requests.put
 
+def helper_get_verify_ssl_func(verify_ssl_certificate):
+    if verify_ssl_certificate == "1":
+        return True
+    elif verify_ssl_certificate == "0":
+        return False
+
 def process(data):    
     configuration = data['configuration']
     results = data['result']
@@ -35,9 +41,11 @@ def process(data):
     input_custom_headers = configuration.get('custom_headers')
     payload = configuration.get('payload')
     method = configuration.get('method')
+    verify_ssl_certificate = configuration.get('verify_ssl_certificate')
     qs_params = configuration.get('qs_params')
     timeout = 30
     custom_headers = {}
+    verify_ssl_certificate = helper_get_verify_ssl_func(verify_ssl_certificate)
     requests_func = helper_get_requests_func(method)
 
     if input_custom_headers is not None and len(input_custom_headers) > 0:
@@ -53,7 +61,7 @@ def process(data):
         logging.info("ERROR httpalert job={} endpoint={} endpoint does not start https:// ".format(data['sid'],endpoint))
         return
 
-    response = requests_func(endpoint, params=qs_params, data=payload, headers=custom_headers, timeout=timeout)
+    response = requests_func(endpoint, params=qs_params, data=payload, headers=custom_headers, timeout=timeout, verify=verify_ssl_certificate)
     logging.info("httpalert Job={} endpoint={} status_code={} ".format(data['sid'],endpoint,response.status_code))
     
 
@@ -67,6 +75,7 @@ if len(sys.argv) > 1 and sys.argv[1] == "--test":
         "configuration" : {
             'endpoint' : "https://example.com/post",
             'method' : "post",
+            'verify_ssl_certificate' : "True",
             'qs_params' : "test=true",
             'payload' : "This is the body"
         },
@@ -76,4 +85,3 @@ if len(sys.argv) > 1 and sys.argv[1] == "--test":
         }
     }
     process(data)
-

--- a/default/app.conf
+++ b/default/app.conf
@@ -1,6 +1,6 @@
 [launcher]
 author = brendanmacooper
-version = 8.1.0
+version = 8.1.1
 description = Send a HTTP request with a customised payload & headers
 
 [ui]

--- a/default/data/ui/alerts/httpalert.html
+++ b/default/data/ui/alerts/httpalert.html
@@ -35,5 +35,14 @@
 </select>
     </div>
 </div>
+<div class="control-group">
+	<label class="control-label" for="httpalert_verify_ssl_certificate">Verify SSL Certificate <span class="required">*</span> </label>
+    <div class="controls">
+<select name="action.httpalert.param.verify_ssl_certificate" id="httpalert_verify_ssl_certificate">
+        <option value=1>True</option>
+        <option value=0>False</option>
+</select>
+    </div>
+</div>
     
 </form>


### PR DESCRIPTION
Hi,

I've added an option to choose between Verify SSL Certificate - True or False.
The reason I've chose the values 0 or 1 in the HTML code, is that initially I wrote True/False, and python read it as 1/0, So I went with that, and added the function **helper_get_verify_ssl_func**

![image](https://user-images.githubusercontent.com/29895680/158842203-3d490d3e-e5e6-4ed1-81fe-7e7fccba9ccd.png)

Bar.